### PR TITLE
MF-375: Grid layout issues

### DIFF
--- a/src/app/components/DataGrid.tsx
+++ b/src/app/components/DataGrid.tsx
@@ -484,7 +484,6 @@ export const DataGrid = (props: DataGridProps) => {
             )}
           </GridWidget>
         </Grid>
-        <div css="width: 100%; height: 100px;" />
       </Hidden>
     </React.Fragment>
   );

--- a/src/app/modules/landing-module/layout.tsx
+++ b/src/app/modules/landing-module/layout.tsx
@@ -10,6 +10,12 @@ export const LandingLayout = (props: DataGridProps) => {
       <ModuleContainer>
         <DataGrid {...props} />
       </ModuleContainer>
+      <div
+        css={`
+          height: 16px;
+          width: 100%;
+        `}
+      />
     </>
   );
 };


### PR DESCRIPTION
Could not reproduce the layout issue stated in this ticket: https://zimmermanzimmerman.atlassian.net/browse/MF-375, the issue may have occurred in a previous version of the app. 

Removed the extra spacing beneath the about and result cards. 